### PR TITLE
[FEAT] Let hand joints move faster

### DIFF
--- a/include/params.hpp
+++ b/include/params.hpp
@@ -36,7 +36,9 @@ const uint8_t servoInitAngles[] = {10, 170, 80, 10, 80, 80, 0, 180, 180, 180, 18
 
 #define ESP32_LED 2
 #define UPDATE_ARM_DELAY 1.0
-const float ARM_MOVEMENT_STEP = 1.0;
+#define HAND_BIAS 6
+const float ARM_MOVEMENT_STEP = 10.0;
+const float HAND_MOVEMENT_STEP = 180.0;
 const size_t NUM_SERVOS = 11;
 
 static_assert(sizeof(servoMinAngles) == NUM_SERVOS * sizeof(uint8_t));

--- a/src/armDriver.cpp
+++ b/src/armDriver.cpp
@@ -62,13 +62,27 @@ void ArmManager::getCurrentAngles(float currentAngles[]) {
 }
 
 void ArmManager::moveArm() {
-    for (uint8_t i = 0; i < this->numServos; ++i) {
+    uint8_t i = 0;
+    for (; i < HAND_BIAS; ++i) {
         if (abs(this->servoCurrentAngles[i] - this->servoTargetAngles[i]) >= ARM_MOVEMENT_STEP) {
             float step = (this->servoTargetAngles[i] > this->servoCurrentAngles[i]) ? ARM_MOVEMENT_STEP : -ARM_MOVEMENT_STEP;
             this->servoCurrentAngles[i] += step;
-            // this line will occur some delay to let device work not properly
-            // please make sure you had connect to PCA9685 pwm driver.
-            setServoAngle(i, this->servoCurrentAngles[i]);
+        } else {
+            this->servoCurrentAngles[i] = this->servoTargetAngles[i];
         }
+        // this line will occur some delay to let device work not properly
+        // please make sure you had connect to PCA9685 pwm driver.
+        setServoAngle(i, this->servoCurrentAngles[i]);
+    }
+    for (; i < this->numServos; ++i) {
+        if (abs(this->servoCurrentAngles[i] - this->servoTargetAngles[i]) >= HAND_MOVEMENT_STEP) {
+            float step = (this->servoTargetAngles[i] > this->servoCurrentAngles[i]) ? HAND_MOVEMENT_STEP : -HAND_MOVEMENT_STEP;
+            this->servoCurrentAngles[i] += step;
+        } else {
+            this->servoCurrentAngles[i] = this->servoTargetAngles[i];
+        }
+        // this line will occur some delay to let device work not properly
+        // please make sure you had connect to PCA9685 pwm driver.
+        setServoAngle(i, this->servoCurrentAngles[i]);
     }
 }


### PR DESCRIPTION
These changes set the arm-changing step to 10.0 and the hand-changing step to 180.0.
It increases the speed of the arm and move hand joints immediately.
